### PR TITLE
Updating to correct error.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "bigbrain-datalad"]
+	path = bigbrain-datalad
+	url = https://github.com/conpdatasets/bigbrain-datalad/


### PR DESCRIPTION
The initial fork of this dataset was meant to contain two changes, an update to the DATS module and a submodule link to the raw BigBrain dataset, and the latter was not saved before forking; this PR corrects that omission. 